### PR TITLE
Add simple React OIDC tester

### DIFF
--- a/oidc_ui_tester/README.md
+++ b/oidc_ui_tester/README.md
@@ -1,1 +1,12 @@
-# oidc U Tester
+# OIDC UI Tester
+
+A simple React single-page application demonstrating an OpenID Connect login flow using `oidc-client-ts`.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+The app expects an OIDC provider running at the URL specified by the `REACT_APP_OIDC_AUTHORITY` environment variable.

--- a/oidc_ui_tester/index.html
+++ b/oidc_ui_tester/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OIDC React Tester</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/oidc_ui_tester/package.json
+++ b/oidc_ui_tester/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "oidc_ui_tester",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "oidc-client-ts": "^2.2.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.15.0",
+    "jwt-decode": "^3.1.2"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.4.9"
+  }
+}

--- a/oidc_ui_tester/src/App.jsx
+++ b/oidc_ui_tester/src/App.jsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { userManager } from './oidc';
+import jwtDecode from 'jwt-decode';
+
+export default function App() {
+  const [user, setUser] = useState(null);
+  const [claims, setClaims] = useState(null);
+
+  useEffect(() => {
+    userManager.getUser().then(u => {
+      if (u) {
+        setUser(u);
+        setClaims(parseJwt(u.id_token));
+      }
+    });
+  }, []);
+
+  const parseJwt = token => {
+    try {
+      return jwtDecode(token);
+    } catch (e) {
+      return null;
+    }
+  };
+
+  const login = () => {
+    userManager.signinRedirect();
+  };
+
+  const logout = () => {
+    userManager.signoutRedirect();
+    setUser(null);
+    setClaims(null);
+  };
+
+  const refreshToken = async () => {
+    const refreshed = await userManager.signinSilent();
+    setUser(refreshed);
+    setClaims(parseJwt(refreshed.id_token));
+  };
+
+  if (!user) {
+    return (
+      <div>
+        <h1>React OIDC Tester</h1>
+        <button onClick={login}>Login</button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h1>React OIDC Tester</h1>
+      <p><strong>Access Token:</strong> {user.access_token}</p>
+      <p><strong>ID Token:</strong> {user.id_token}</p>
+      <p><strong>Refresh Token:</strong> {user.refresh_token}</p>
+      {claims && (
+        <div>
+          <h2>ID Token Claims</h2>
+          <pre>{JSON.stringify(claims, null, 2)}</pre>
+        </div>
+      )}
+      <button onClick={refreshToken}>Refresh Token</button>
+      <button onClick={logout}>Logout</button>
+    </div>
+  );
+}

--- a/oidc_ui_tester/src/CallbackPage.jsx
+++ b/oidc_ui_tester/src/CallbackPage.jsx
@@ -1,0 +1,17 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { userManager } from './oidc';
+
+export default function CallbackPage() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    async function handleCallback() {
+      await userManager.signinRedirectCallback();
+      navigate('/');
+    }
+    handleCallback();
+  }, [navigate]);
+
+  return <div>Processing login...</div>;
+}

--- a/oidc_ui_tester/src/main.jsx
+++ b/oidc_ui_tester/src/main.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import App from './App';
+import CallbackPage from './CallbackPage';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/callback" element={<CallbackPage />} />
+        <Route path="/*" element={<App />} />
+      </Routes>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/oidc_ui_tester/src/oidc.js
+++ b/oidc_ui_tester/src/oidc.js
@@ -1,9 +1,9 @@
 import { UserManager, WebStorageStateStore } from 'oidc-client-ts';
 
 // OIDC configuration. Replace values or use environment variables as needed.
-const OIDC_AUTHORITY = process.env.REACT_APP_OIDC_AUTHORITY || 'http://localhost:3000';
-const CLIENT_ID = process.env.REACT_APP_OIDC_CLIENT_ID || 'oidc_ui_tester';
-const REDIRECT_URI = process.env.REACT_APP_OIDC_REDIRECT_URI || `${window.location.origin}/callback`;
+const OIDC_AUTHORITY = "http://localhost:5001/netware-326600/us-central1/oidc";//process.env.REACT_APP_OIDC_AUTHORITY || 'http://localhost:3000';
+const CLIENT_ID = 'oidc_ui_tester';//process.env.REACT_APP_OIDC_CLIENT_ID || 'oidc_ui_tester';
+const REDIRECT_URI = `${window.location.origin}/callback`;// process.env.REACT_APP_OIDC_REDIRECT_URI || `${window.location.origin}/callback`;
 
 const config = {
   authority: OIDC_AUTHORITY,

--- a/oidc_ui_tester/src/oidc.js
+++ b/oidc_ui_tester/src/oidc.js
@@ -1,0 +1,18 @@
+import { UserManager, WebStorageStateStore } from 'oidc-client-ts';
+
+// OIDC configuration. Replace values or use environment variables as needed.
+const OIDC_AUTHORITY = process.env.REACT_APP_OIDC_AUTHORITY || 'http://localhost:3000';
+const CLIENT_ID = process.env.REACT_APP_OIDC_CLIENT_ID || 'oidc_ui_tester';
+const REDIRECT_URI = process.env.REACT_APP_OIDC_REDIRECT_URI || `${window.location.origin}/callback`;
+
+const config = {
+  authority: OIDC_AUTHORITY,
+  client_id: CLIENT_ID,
+  redirect_uri: REDIRECT_URI,
+  post_logout_redirect_uri: window.location.origin,
+  response_type: 'code',
+  scope: 'openid profile email offline_access',
+  userStore: new WebStorageStateStore({ store: window.localStorage })
+};
+
+export const userManager = new UserManager(config);

--- a/oidc_ui_tester/vite.config.js
+++ b/oidc_ui_tester/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- create OIDC React tester app using oidc-client-ts under `oidc_ui_tester`
- implement login, callback handling, token display and refresh
- document how to start the app

## Testing
- `npm test` in `oidc_server`

------
https://chatgpt.com/codex/tasks/task_e_68537a61d3788323a9db4c46c542ea77