### PR TITLE
Fix provider redirect host

### DIFF
--- a/oidc_server/test/index.test.js
+++ b/oidc_server/test/index.test.js
@@ -16,4 +16,17 @@ describe('OIDC Cloud Function', function() {
       })
       .end(done);
   });
+
+  it('uses issuer path for endpoints', function(done) {
+    process.env.OIDC_ISSUER = 'http://example.com/test';
+    delete require.cache[require.resolve('..')];
+    const { oidc: instance } = require('..');
+    request(instance)
+      .get('/.well-known/openid-configuration')
+      .expect(200)
+      .expect(res => {
+        assert.strictEqual(res.body.authorization_endpoint, 'http://example.com/test/auth');
+      })
+      .end(done);
+  });
 });


### PR DESCRIPTION
## Summary
- trust proxy headers and enable proxy support so `oidc-provider` uses the configured issuer
- inject `X-Forwarded-*` headers and mount path
- handle repeated initialization in tests and check path usage

## Testing
- `npm test -s` in `oidc_server`


------
https://chatgpt.com/codex/tasks/task_e_6854b5bd05e083238179ce12435e749e